### PR TITLE
Check existance of optional header explicitly

### DIFF
--- a/include/CortidQCT/src/Optional.h
+++ b/include/CortidQCT/src/Optional.h
@@ -14,7 +14,7 @@
 
 #include <ostream>
 
-#if __cplusplus >= 201703L
+#if __has_include(<optional>)
 #  include <optional>
 #elif __has_include(<experimental/optional>)
 #  include <experimental/optional>


### PR DESCRIPTION
The language standard check (i.e. __cplusplus >= 201703L) is not sufficient since the used STL might not have an optional implementation. So checking with __has_include(<optional>) is the safer way.
This fixes #15