### PR TITLE
Implement per-vertex log likelihood

### DIFF
--- a/bindings/C/include/CortidQCT/C/CortidQCT.h
+++ b/bindings/C/include/CortidQCT/C/CortidQCT.h
@@ -387,6 +387,12 @@ CQCT_meshFitterResultMinimumDisplacementNorm(CQCT_MeshFitterResult result);
 CQCT_EXTERN float
 CQCT_meshFitterResultLogLikelihood(CQCT_MeshFitterResult result);
 
+/// Copies the current per-vertex log likelihood vector of the model given the
+/// input volume to the given buffer
+CQCT_EXTERN float
+CQCT_meshFitterResultCopyPerVertexLogLikelihood(CQCT_MeshFitterResult result,
+                                                float **buffer);
+
 /// Sets the current log likelihood of the model given the input volume
 CQCT_EXTERN void
 CQCT_meshFitterResultSetLogLikelihood(CQCT_MeshFitterResult result, float ll);

--- a/bindings/C/src/MeshFitterState.cpp
+++ b/bindings/C/src/MeshFitterState.cpp
@@ -220,6 +220,24 @@ CQCT_meshFitterResultLogLikelihood(CQCT_MeshFitterResult result) {
   return state.logLikelihood;
 }
 
+CORTIDQCT_C_EXPORT CQCT_EXTERN float
+CQCT_meshFitterResultCopyPerVertexLogLikelihood(CQCT_MeshFitterResult result,
+                                                float **buffer) {
+  using std::copy;
+  assert(result != nullptr);
+  assert(buffer != nullptr);
+
+  auto const &pvLL = result->impl.objPtr->state.perVertexLogLikelihood;
+
+  auto const size = pvLL.size() * sizeof(float);
+
+  if (*buffer == nullptr) { *buffer = static_cast<float *>(malloc(size)); }
+
+  copy(pvLL.cbegin(), pvLL.cend(), *buffer);
+
+  return size;
+}
+
 CORTIDQCT_C_EXPORT CQCT_EXTERN void
 CQCT_meshFitterResultSetLogLikelihood(CQCT_MeshFitterResult result, float ll) {
   assert(result != nullptr);

--- a/bindings/matlab/+CortidQCT/+lib/MeshFitterResult.m
+++ b/bindings/matlab/+CortidQCT/+lib/MeshFitterResult.m
@@ -13,6 +13,7 @@ classdef MeshFitterResult < CortidQCT.lib.ObjectBase
     volumeSamples
     minimumDisplacementNorm
     logLikelihood
+    perVertexLogLikelihood
     effectiveSigmaS
     iteration
     converged
@@ -131,6 +132,15 @@ classdef MeshFitterResult < CortidQCT.lib.ObjectBase
     function logLikelihood = get.logLikelihood(obj)
       import CortidQCT.lib.ObjectBase;
       logLikelihood = ObjectBase.call('meshFitterResultLogLikelihood', obj.handle);
+    end
+
+    function perVertexLogLikelihood = get.perVertexLogLikelihood(obj)
+      import CortidQCT.lib.ObjectBase;
+      buffer = libpointer('singlePtr', zeros(obj.mesh.vertexCount, 1, 'single'));
+      res = ObjectBase.call('meshFitterResultCopyPerVertexLogLikelihood', obj.handle, buffer);
+      assert(res == 4 * obj.mesh.vertexCount, 'Size mismatch');
+
+      perVertexLogLikelihood = buffer.Value;
     end
 
     function obj = set.logLikelihood(obj, ll)

--- a/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
+++ b/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
@@ -359,6 +359,12 @@ CQCT_meshFitterResultMinimumDisplacementNorm(CQCT_MeshFitterResult result);
 CQCT_EXTERN float
 CQCT_meshFitterResultLogLikelihood(CQCT_MeshFitterResult result);
 
+/// Copies the current per-vertex log likelihood vector of the model given the
+/// input volume to the given buffer
+CQCT_EXTERN float
+CQCT_meshFitterResultCopyPerVertexLogLikelihood(CQCT_MeshFitterResult result,
+                                                float **buffer);
+
 /// Sets the current log likelihood of the model given the input volume
 CQCT_EXTERN void
 CQCT_meshFitterResultSetLogLikelihood(CQCT_MeshFitterResult result, float ll);

--- a/include/CortidQCT/src/MeshFitter.h
+++ b/include/CortidQCT/src/MeshFitter.h
@@ -134,6 +134,8 @@ public:
     float minDisNorm = std::numeric_limits<float>::max();
     /// Log likeihood of deformedMesh
     float logLikelihood = -std::numeric_limits<float>::max();
+    /// Per-vertex log likelihood vector
+    std::vector<float> perVertexLogLikelihood;
     /// Effective sigmaS
     float effectiveSigmaS = .0f;
     /// Iteration count

--- a/lib/DisplacementOptimizer.cpp
+++ b/lib/DisplacementOptimizer.cpp
@@ -188,6 +188,24 @@ operator()(Eigen::MatrixBase<DerivedN> const &N,
 }
 
 template <class DerivedN, class DerivedL, class DerivedM>
+Eigen::Matrix<typename DerivedM::Scalar, Eigen::Dynamic, 1>
+DisplacementOptimizer::logLikelihoodVector(
+    Eigen::MatrixBase<DerivedN> const &N,
+    Eigen::MatrixBase<DerivedL> const &labels,
+    Eigen::MatrixBase<DerivedM> const &measurements) {
+  using Scalar = typename DerivedM::Scalar;
+  using Vector = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
+
+  updateModelSamplingPositions(model_, N, labels, measurements,
+                               modelSamplingPositions_);
+
+  Vector modelSamples(measurements.size());
+  modelSampler_(modelSamplingPositions_, .0f, modelSamples);
+
+  return modelSamples;
+}
+
+template <class DerivedN, class DerivedL, class DerivedM>
 float DisplacementOptimizer::logLikelihood(
     Eigen::MatrixBase<DerivedN> const &N,
     Eigen::MatrixBase<DerivedL> const &labels,
@@ -195,13 +213,7 @@ float DisplacementOptimizer::logLikelihood(
 
   using Eigen::VectorXf;
 
-  updateModelSamplingPositions(model_, N, labels, measurements,
-                               modelSamplingPositions_);
-
-  VectorXf modelSamples(measurements.size());
-  modelSampler_(modelSamplingPositions_, .0f, modelSamples);
-
-  return modelSamples.sum();
+  return logLikelihoodVector(N, labels, measurements).sum();
 }
 
 template DisplacementOptimizer::DisplacementsWeightsPair DisplacementOptimizer::
@@ -237,6 +249,15 @@ operator()<
     float &);
 
 template float DisplacementOptimizer::logLikelihood<
+    Eigen::Transpose<const Eigen::Map<Eigen::Matrix<float, 3, Eigen::Dynamic>>>,
+    Eigen::Map<LabelVector>, Eigen::Map<Eigen::VectorXf>>(
+    Eigen::MatrixBase<Eigen::Transpose<
+        const Eigen::Map<Eigen::Matrix<float, 3, Eigen::Dynamic>>>> const &,
+    Eigen::MatrixBase<Eigen::Map<LabelVector>> const &,
+    Eigen::MatrixBase<Eigen::Map<Eigen::VectorXf>> const &);
+
+template Eigen::Matrix<float, Eigen::Dynamic, 1>
+DisplacementOptimizer::logLikelihoodVector<
     Eigen::Transpose<const Eigen::Map<Eigen::Matrix<float, 3, Eigen::Dynamic>>>,
     Eigen::Map<LabelVector>, Eigen::Map<Eigen::VectorXf>>(
     Eigen::MatrixBase<Eigen::Transpose<

--- a/lib/DisplacementOptimizer.h
+++ b/lib/DisplacementOptimizer.h
@@ -49,8 +49,16 @@ public:
              std::size_t nonDecrease, float &effectiveSigmaS);
 
   /**
-   * @brief Compute the log likelihood of the current model for the given
-   * displacement.
+   * @brief Computes the per-veretx log likelihood of the current model.
+   */
+  template <class DerivedN, class DerivedL, class DerivedM>
+  Eigen::Matrix<typename DerivedM::Scalar, Eigen::Dynamic, 1>
+  logLikelihoodVector(Eigen::MatrixBase<DerivedN> const &N,
+                      Eigen::MatrixBase<DerivedL> const &labels,
+                      Eigen::MatrixBase<DerivedM> const &measurements);
+
+  /**
+   * @brief Compute the log likelihood of the current model.
    */
   template <class DerivedN, class DerivedL, class DerivedM>
   float logLikelihood(Eigen::MatrixBase<DerivedN> const &N,
@@ -110,6 +118,15 @@ DisplacementOptimizer::operator()<
     float &);
 
 extern template float DisplacementOptimizer::logLikelihood<
+    Eigen::Transpose<const Eigen::Map<Eigen::Matrix<float, 3, Eigen::Dynamic>>>,
+    Eigen::Map<LabelVector>, Eigen::Map<Eigen::VectorXf>>(
+    Eigen::MatrixBase<Eigen::Transpose<
+        const Eigen::Map<Eigen::Matrix<float, 3, Eigen::Dynamic>>>> const &,
+    Eigen::MatrixBase<Eigen::Map<LabelVector>> const &,
+    Eigen::MatrixBase<Eigen::Map<Eigen::VectorXf>> const &);
+
+extern template Eigen::Matrix<float, Eigen::Dynamic, 1>
+DisplacementOptimizer::logLikelihoodVector<
     Eigen::Transpose<const Eigen::Map<Eigen::Matrix<float, 3, Eigen::Dynamic>>>,
     Eigen::Map<LabelVector>, Eigen::Map<Eigen::VectorXf>>(
     Eigen::MatrixBase<Eigen::Transpose<


### PR DESCRIPTION
Make per-vertex log likelihood available in the MeshFitter::Result object.
This closes #41.
