### PR TITLE
Fix DLL exports issue #43

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 # Create project
 project(
   CortidQCT
-  VERSION 1.2.1
+  VERSION 1.2.2
   LANGUAGES C CXX
 )
 

--- a/README.md
+++ b/README.md
@@ -8,19 +8,14 @@ This software is based on
 
 ## Binary Releases
 
-Version | File | OS | Comment
--------:|:----:|:--:|:-------
-**v1.2.1**  |  [CortidQCT-v1.2.1-win64.zip](https://github.com/ithron/CortidQCT/releases/download/v1.2.1/CortidQCT-v1.2.1-win64.zip) | Windows x64| CLI, C++ library, C bindings, MATLAB bindings, headers, Matlab toolbox
- &nbsp;  | [CortidQCT-v1.2.1-macOS-Mojave.zip](https://github.com/ithron/CortidQCT/releases/download/v1.2.1/CortidQCT-v1.2.1-macOS-Mojave.zip) | macOS Mojave |
-&nbsp; | [CortidQCT-v1.2.1-x86_64-linux-gnu-ubuntu-18.04.tar.gz](https://github.com/ithron/CortidQCT/releases/download/v1.2.1/CortidQCT-v1.2.1-x86_64-linux-gnu-ubuntu-18.04.tar.gz) | Ubuntu Linux 18.04 x86_64 |
-&nbsp; | [CortidQCT-v1.2.1.mltbx](https://github.com/ithron/CortidQCT/releases/download/v1.2.1/CortidQCT-v1.2.1.mltbx) | Windows x64, Ubuntu Linux 18.04 x86_64, macOS Mojave | Ready to install MATLAB toolbox, 64bit
-v1.2.0  |  [CortidQCT-v1.2.0-win64.zip](https://github.com/ithron/CortidQCT/releases/download/v1.2.0/CortidQCT-v1.2.0-win64.zip) | Windows x64| CLI, C++ library, C bindings, MATLAB bindings, headers, Matlab toolbox
- &nbsp;  | [CortidQCT-v1.2.0-macOS-Mojave.zip](https://github.com/ithron/CortidQCT/releases/download/v1.2.0/CortidQCT-v1.2.0-macOS-Mojave.zip) | macOS Mojave |
-&nbsp; | [CortidQCT-v1.2.0-x86_64-linux-gnu-ubuntu-18.04.tar.gz](https://github.com/ithron/CortidQCT/releases/download/v1.2.0/CortidQCT-v1.2.0-x86_64-linux-gnu-ubuntu-18.04.tar.gz) | Ubuntu Linux 18.04 x86_64 |
-&nbsp; | [CortidQCT-v1.2.0.mltbx](https://github.com/ithron/CortidQCT/releases/download/v1.2.0/CortidQCT-v1.2.0.mltbx) | Windows x64, Ubuntu Linux 18.04 x86_64, macOS Mojave | Ready to install MATLAB toolbox, 64bit
-v1.1.0  |  [CortidQCT-v1.1.0-Windows-x64.zip](https://github.com/ithron/CortidQCT/releases/download/v1.1.0/CortidQCT-v1.1.0-Windows-x64.zip) | Windows x64 | Complete: CLI, C++ library, C bindings, headers, Matlab toolbox
-v1.0.1  |  [CortidQCT-v1.0.1-Windows-x64.zip](https://github.com/ithron/CortidQCT/releases/download/v1.0.1/CortidQCT-v1.0.1-Windows-x64.zip) | Windows x64 | Complete: CLI, library, headers, Matlab toolbox
-v1.0.0  | [CortidQCT_CLI-1.0.0-Windows-x64.zip](https://github.com/ithron/CortidQCT/releases/download/v1.0.0/CortidQCT_CLI-1.0.0-Windows-x64.zip) | Windows x64 | CLI binary only
+The current release is **v1.2.2**:
+
+- [CortidQCT-v1.2.2-win64.zip](https://github.com/ithron/CortidQCT/releases/download/v1.2.2/CortidQCT-v1.2.2-win64.zip) Windows x64 binary release
+- [CortidQCT-v1.2.2-macOS-Mojave.zip](https://github.com/ithron/CortidQCT/releases/download/v1.2.2/CortidQCT-v1.2.2-macOS-Mojave.zip) macOS Mojave binary release
+- [CortidQCT-v1.2.2-x86_64-linux-gnu-ubuntu-18.04.tar.gz](https://github.com/ithron/CortidQCT/releases/download/v1.2.2/CortidQCT-v1.2.2-x86_64-linux-gnu-ubuntu-18.04.tar.gz) Ubuntu Linux 18.04 x86_64 binary release
+- [CortidQCT-v1.2.2.mltbx](https://github.com/ithron/CortidQCT/releases/download/v1.2.2/CortidQCT-v1.2.2.mltbx) MATLAB toolbox
+
+Older releases can be found [here](https://github.com/ithron/CortidQCT/releases).
 
 ## Build from Source
 The build instructions below are for *NIX (Unix/Linux/macOS) systems only.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool for automatic cortical shape identification for QCT scans.
 
 This software is based on
 "**An Analysis by Synthesis Approach for Automatic Vertebral Shape Identification in Clinical QCT**" by
-*[Stefan Reinhold](https://orcid.org/0000-0003-3117-1569), [Timo Damm](https://orcid.org/0000-0002-5595-5205), Lukas Huber, [Reimer Andresen](https://orcid.org/0000-0002-1575-525X), Reinhard Barkmann, [Claus-C. Glüer](https://orcid.org/0000-0003-3539-8955) and [Reinhard Koch](https://orcid.org/0000-0003-4398-1569)*, accepted for publication in Springer LNCS, presented on "German Conference on Pattern Recognition 2018".
+*[Stefan Reinhold](https://orcid.org/0000-0003-3117-1569), [Timo Damm](https://orcid.org/0000-0002-5595-5205), Lukas Huber, [Reimer Andresen](https://orcid.org/0000-0002-1575-525X), Reinhard Barkmann, [Claus-C. Glüer](https://orcid.org/0000-0003-3539-8955) and [Reinhard Koch](https://orcid.org/0000-0003-4398-1569)*, accepted for publication in Springer LNCS, presented on "German Conference on Pattern Recognition 2018". [arXiv](https://arxiv.org/abs/1812.00693)
 
 ## Binary Releases
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 # Create project
 project(
   CortidQCTApplication
-  VERSION 1.1.0
+  VERSION 1.2.2
   LANGUAGES CXX
 )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '1.2.1.{build}'
+version: '1.2.2.{build}'
 
 build:
     verbosity: detailed

--- a/bindings/C/CMakeLists.txt
+++ b/bindings/C/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(
   CortidQCT-C-Bindings
-  VERSION 1.2.1
+  VERSION 1.2.2
   LANGUAGES CXX
 )
 

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(
   CortidQCT-MATLAB-Bindings
-  VERSION 1.2.1
+  VERSION 1.2.2
   LANGUAGES C
 )
 

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -26,7 +26,10 @@ target_include_directories(matlab-bindings
 )
 
 target_link_libraries(matlab-bindings PRIVATE CortidQCT::Bindings::C)
-set_target_properties(matlab-bindings PROPERTIES OUTPUT_NAME "CortidQCT-Matlab")
+set_target_properties(matlab-bindings PROPERTIES
+  OUTPUT_NAME "CortidQCT-Matlab"
+  WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
 
 add_library(CortidQCT::Bindings::Matlab ALIAS matlab-bindings)
 

--- a/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
+++ b/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
@@ -48,11 +48,11 @@ CQCT_EXTERN void CQCT_release(Id obj);
 CQCT_EXTERN Id CQCT_autorelease(Id obj);
 
 /// Adds a new autorelease pool to the stack
-CQCT_EXTERN void CQCT_autoreleasePoolPush();
+CQCT_EXTERN void CQCT_autoreleasePoolPush(void);
 
 /// Removes the current autorelease pool from the stack and releases all of
 /// its objects
-CQCT_EXTERN void CQCT_autoreleasePoolPop();
+CQCT_EXTERN void CQCT_autoreleasePoolPop(void);
 
 /// @}
 
@@ -94,7 +94,7 @@ struct CQCT_VoxelVolume_t;
 typedef struct CQCT_VoxelVolume_t *CQCT_VoxelVolume;
 
 /// Creates an empty voxel volume
-CQCT_EXTERN CQCT_VoxelVolume CQCT_createVoxelVolume();
+CQCT_EXTERN CQCT_VoxelVolume CQCT_createVoxelVolume(void);
 
 /// Loads the voxel volume from file
 CQCT_EXTERN int CQCT_voxelVolumeLoadFromFile(CQCT_VoxelVolume volume,
@@ -146,7 +146,7 @@ struct CQCT_Mesh_t;
 typedef struct CQCT_Mesh_t *CQCT_Mesh;
 
 /// Creates an empty mesh
-CQCT_EXTERN CQCT_Mesh CQCT_createMesh();
+CQCT_EXTERN CQCT_Mesh CQCT_createMesh(void);
 
 /**
  * @brief Creates and loads a mesh from file.
@@ -266,7 +266,7 @@ struct CQCT_ColorToLabelMap_t;
 typedef struct CQCT_ColorToLabelMap_t *CQCT_ColorToLabelMap;
 
 /// Creates a default color to label map
-CQCT_EXTERN CQCT_ColorToLabelMap CQCT_createColorToLabelMap();
+CQCT_EXTERN CQCT_ColorToLabelMap CQCT_createColorToLabelMap(void);
 
 /// Loads the mapping from YAML file
 CQCT_EXTERN int CQCT_colorToLabelMapLoadFromFile(CQCT_ColorToLabelMap map,

--- a/bindings/matlab/src/matlab-addons.c
+++ b/bindings/matlab/src/matlab-addons.c
@@ -42,8 +42,8 @@ CQCT_voxelVolumeVoxelDepth(CQCT_VoxelVolume volume) {
   return CQCT_voxelVolumeVoxelSize(volume).depth;
 }
 
-extern void CQCT_autoreleasePoolPush();
-extern void CQCT_autoreleasePoolPop();
+extern void CQCT_autoreleasePoolPush(void);
+extern void CQCT_autoreleasePoolPop(void);
 
 #ifdef _WIN32
 
@@ -66,6 +66,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
 }
 
 #else
+
+CORTIDQCT_MATLAB_EXPORT void __attribute__((constructor)) CQCT_init(void);
+CORTIDQCT_MATLAB_EXPORT void __attribute__((destructor)) CQCT_fini(void);
 
 CORTIDQCT_MATLAB_EXPORT void __attribute__((constructor)) CQCT_init(void) {
   CQCT_autoreleasePoolPush();

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -7,7 +7,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Init.cmake)
 
 project(
   CortidQCT-Common
-  VERSION 1.2.1
+  VERSION 1.2.2
   LANGUAGES CXX
 )
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -26,12 +26,6 @@ option(CortidQCT_WITH_WERROR "Treat warnings as errors" ON)
 ############################
 # Targets
 
-project(
-  CortidQCT-Common
-  VERSION 1.0.0
-  LANGUAGES CXX
-)
-
 add_library(Common INTERFACE)
 
 target_compile_features(Common

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,7 +7,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Init.cmake)
 
 project(
   LibCortidQCT
-  VERSION 1.2.1
+  VERSION 1.2.2
   LANGUAGES CXX
 )
 

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(
   CortidQCT-MATLAB
-  VERSION 1.2.1
+  VERSION 1.2.2
   LANGUAGES C
 )
 

--- a/matlab/CortidQCT.prj
+++ b/matlab/CortidQCT.prj
@@ -9,7 +9,7 @@
 
 For details visit https://github.com/ithron/CortidQCT</param.description>
     <param.screenshot />
-    <param.version>1.2.1</param.version>
+    <param.version>1.2.2</param.version>
     <param.output>${PROJECT_ROOT}/CortidQCT.mltbx</param.output>
     <param.products.name>
       <item>MATLAB</item>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Init.cmake)
 # Project
 project(
   CortidQCT-Tests
-  VERSION 1.2.1
+  VERSION 1.2.2
   LANGUAGES CXX
 )
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2)
 
 project(
   CortidQCT-Tools
-  VERSION 1.2.1
+  VERSION 1.2.2
 )
 
 ############################

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 
 project(
-  CortidQCT-Examples
+  CortidQCT-Tools
   VERSION 1.2.1
 )
 


### PR DESCRIPTION
The DLL library used in the MATLAB toolbox was missing the symbols of the C-Bindings library (#43).
This is fixed by this PR by forcing the Matlab-Bindings target to export all symbols.