### PR TITLE
Add API to create and modify meshes from within C or MATLAB

### DIFF
--- a/bindings/C/include/CortidQCT/C/CortidQCT.h
+++ b/bindings/C/include/CortidQCT/C/CortidQCT.h
@@ -179,11 +179,32 @@ typedef struct CQCT_Mesh_t *CQCT_Mesh;
 CQCT_EXTERN CQCT_Mesh CQCT_createMesh();
 
 /**
+ * @brief Creates an mesh and reserve space for vertices and indices.
+ *
+ * Creates a mesh data structure and allocate memory for vertices, indices and
+ * labels.
+ *
+ * @param[in] nVertices Number of vertices to allocate memory for
+ * @param[in] nTriangles Number of triangles to allocate memory for
+ * @param[out] error In case of an error, an error object is copied to
+ * `*error`. NULL may be passed here to not get any error objects.
+ * @return A newly created CQCT_Mesh opbject or NULL on error.
+ * @note The ownership of the mesh object is transfered to the caller.
+ * @note The ownership of the error object is NOT transfered to teh caller.
+ * @note It is very unlikely that this function returns an error. The only
+ * reason for failure is when the system is unable to allocate enough memory.
+ * It is therefore kind of save to pass NULL for `error` here.
+ */
+CQCT_EXTERN CQCT_Mesh CQCT_createMeshAndAllocateMemory(size_t nVertices,
+                                                       size_t nTriangles,
+                                                       CQCT_Error *error);
+
+/**
  * @brief Creates and loads a mesh from file.
  *
  * @param[in] filename path to the file to load the mesh from
- * @param[out] error In case of an error, an error object is copied to `*error`.
- *   NULL may be passed here to not get any error object.
+ * @param[out] error In case of an error, an error object is copied to
+ * `*error`. NULL may be passed here to not get any error object.
  * @return A newly created Mesh object.
  * @note The ownershop is NOT transfered to the caller.
  * @see CortidQCT::Mesh<float>::loadFromFile()

--- a/bindings/C/include/CortidQCT/C/CortidQCT.h
+++ b/bindings/C/include/CortidQCT/C/CortidQCT.h
@@ -289,6 +289,18 @@ CQCT_EXTERN size_t CQCT_meshTriangleCount(CQCT_Mesh mesh);
 CQCT_EXTERN size_t CQCT_meshCopyVertices(CQCT_Mesh mesh, float **bufferPtr);
 
 /**
+ * @brief Copies the vertices from the given buffer into the mesh data
+ * structure.
+ *
+ * @note Vertices are expected to have the oder [v1x, v1y, v1z, v2x, v2y, v2z,
+ * ...]
+ * @param[in,out] mesh mesh to set the vertices for
+ * @param[in] buffer buffer to copy the vertices from
+ */
+CQCT_EXTERN void CQCT_meshSetVertices(CQCT_Mesh mesh, float const *buffer);
+
+
+/**
  * @brief Copies the mesh's indices into the given buffer
  * @see CQCT_meshCopyVertices()
  */
@@ -296,11 +308,31 @@ CQCT_EXTERN size_t CQCT_meshCopyTriangles(CQCT_Mesh mesh,
                                           ptrdiff_t **bufferPtr);
 
 /**
+ * @brief Copies the triangle indices from the given buffer into the mesh data
+ * structure.
+ *
+ * @note Vertices are expected to have the oder [i11, i12, i13, i21, i22, i23,
+ * ...], where im, denotes the m-th index of the n-th triangle.
+ * @param[in,out] mesh mesh to set the indices for
+ * @param[in] buffer buffer to copy the indices from
+ */
+CQCT_EXTERN void CQCT_meshSetTriangles(CQCT_Mesh mesh, ptrdiff_t const *buffer);
+
+/**
  * @brief Copies the mesh's labels into the given buffer
  * @see CQCT_meshCopyVertices()
  */
 CQCT_EXTERN size_t CQCT_meshCopyLabels(CQCT_Mesh mesh,
                                        unsigned int **bufferPtr);
+
+/**
+ * @brief Copies the vertex labels from the given buffer into the mesh data
+ * structure.
+ *
+ * @param[in,out] mesh mesh to set the indices for
+ * @param[in] buffer buffer to copy the indices from
+ */
+CQCT_EXTERN void CQCT_meshSetLabels(CQCT_Mesh mesh, unsigned int const *buffer);
 
 /// @}
 

--- a/bindings/C/src/Mesh.cpp
+++ b/bindings/C/src/Mesh.cpp
@@ -173,6 +173,18 @@ CORTIDQCT_C_EXPORT CQCT_EXTERN size_t CQCT_meshCopyVertices(CQCT_Mesh mesh,
   return size;
 }
 
+CORTIDQCT_C_EXPORT CQCT_EXTERN void CQCT_meshSetVertices(CQCT_Mesh mesh,
+                                                         float const *buffer) {
+
+  assert(mesh != nullptr);
+  assert(buffer != nullptr);
+
+  auto &obj = *(mesh->impl.objPtr);
+  auto const size = obj.vertexCount() * 3;
+  obj.withUnsafeVertexPointer(
+      [buffer, size](float *dest) { std::copy(buffer, buffer + size, dest); });
+}
+
 CORTIDQCT_C_EXPORT CQCT_EXTERN size_t
 CQCT_meshCopyTriangles(CQCT_Mesh mesh, ptrdiff_t **bufferPtr) {
   assert(mesh != nullptr);
@@ -190,6 +202,19 @@ CQCT_meshCopyTriangles(CQCT_Mesh mesh, ptrdiff_t **bufferPtr) {
   });
 
   return size;
+}
+
+CORTIDQCT_C_EXPORT CQCT_EXTERN void
+CQCT_meshSetTriangles(CQCT_Mesh mesh, ptrdiff_t const *buffer) {
+
+  assert(mesh != nullptr);
+  assert(buffer != nullptr);
+
+  auto &obj = *(mesh->impl.objPtr);
+  auto const size = obj.triangleCount() * 3;
+  obj.withUnsafeIndexPointer([buffer, size](ptrdiff_t *dest) {
+    std::copy(buffer, buffer + size, dest);
+  });
 }
 
 CORTIDQCT_C_EXPORT CQCT_EXTERN size_t
@@ -210,3 +235,17 @@ CQCT_meshCopyLabels(CQCT_Mesh mesh, unsigned int **bufferPtr) {
 
   return size;
 }
+
+CORTIDQCT_C_EXPORT CQCT_EXTERN void
+CQCT_meshSetLabels(CQCT_Mesh mesh, unsigned int const *buffer) {
+
+  assert(mesh != nullptr);
+  assert(buffer != nullptr);
+
+  auto &obj = *(mesh->impl.objPtr);
+  auto const size = obj.vertexCount();
+  obj.withUnsafeLabelPointer([buffer, size](unsigned int *dest) {
+    std::copy(buffer, buffer + size, dest);
+  });
+}
+

--- a/bindings/C/src/Mesh.cpp
+++ b/bindings/C/src/Mesh.cpp
@@ -9,6 +9,21 @@ CORTIDQCT_C_EXPORT CQCT_EXTERN CQCT_Mesh CQCT_createMesh() {
   return static_cast<CQCT_Mesh>(constructObject<Mesh<float>>());
 }
 
+CORTIDQCT_C_EXPORT CQCT_EXTERN CQCT_Mesh CQCT_createMeshAndAllocateMemory(
+    size_t nVertices, size_t nTriangles, CQCT_Error *error) {
+
+  try {
+    return static_cast<CQCT_Mesh>(
+        constructObject<Mesh<float>>(nVertices, nTriangles));
+  } catch (std::exception const &e) {
+    if (error != nullptr) {
+      *error = CQCT_createError(CQCT_ErrorId_Unknown, e.what());
+      CQCT_autorelease(*error);
+    }
+    return nullptr;
+  }
+}
+
 CORTIDQCT_C_EXPORT CQCT_EXTERN CQCT_Mesh CQCT_meshFromFile(const char *filename,
                                                            CQCT_Error *error) {
   return CQCT_meshFromFileWithCustomMapping(filename, nullptr, error);

--- a/bindings/matlab/+CortidQCT/+lib/Mesh.m
+++ b/bindings/matlab/+CortidQCT/+lib/Mesh.m
@@ -46,6 +46,20 @@ classdef Mesh < CortidQCT.lib.ObjectBase
       Vertices = vBuffer.Value';
     end
 
+    function obj = set.Vertices(obj, V)
+      import CortidQCT.lib.ObjectBase;
+
+      if size(V, 2) ~= 3 || not(isa(V, 'single'))
+        error('V must be a Nx3 single matrix')
+      end
+
+      if size(V, 1) ~= obj.VertexCount
+        error('Number of rows of V must match VertexCount')
+      end
+
+      ObjectBase.call('meshSetVertices', obj.handle, V');
+    end
+
     function Indices = get.Indices(obj)
       import CortidQCT.lib.ObjectBase;
       iBuffer = libpointer('longPtr', zeros(3, obj.triangleCount, 'int64'));
@@ -54,12 +68,52 @@ classdef Mesh < CortidQCT.lib.ObjectBase
       Indices = iBuffer.Value' + 1;
     end
 
+    function obj = set.Indices(obj, F)
+      import CortidQCT.lib.ObjectBase;
+
+      if size(F, 2) ~= 3
+        error('V must be a Mx3 single matrix')
+      end
+
+      if ~isa(F, 'int64')
+        F = int64(F);
+      end
+
+      if size(F, 1) ~= obj.VertexCount
+        error('Number of rows of F must match TriangleCount')
+      end
+
+      ObjectBase.call('meshSetTriangles', obj.handle, F');
+    end
+
     function Labels = get.Labels(obj)
       import CortidQCT.lib.ObjectBase;
       lBuffer = libpointer('uint32Ptr', zeros(obj.vertexCount, 1, 'uint32'));
       result = ObjectBase.call('meshCopyLabels', obj.handle, lBuffer);
       assert(result == 4 * length(lBuffer.Value(:)), "Size mismatch");
       Labels = lBuffer.Value;
+    end
+
+    function obj = set.Labels(obj, L)
+      import CortidQCT.lib.ObjectBase;
+
+      if not(isvector(L))
+        error('L must be a vector');
+      end
+
+      if isrow(L)
+        L = L';
+      end
+
+      if ~isa(F, 'uint32')
+        F = uint32(F);
+      end
+
+      if size(F, 1) ~= obj.VertexCount
+        error('Number of rows of L must match TriangleCount')
+      end
+
+      ObjectBase.call('meshSetLabels', obj.handle, L);
     end
 
     %%%%%%%%%%%%%%%%%

--- a/bindings/matlab/+CortidQCT/+lib/Mesh.m
+++ b/bindings/matlab/+CortidQCT/+lib/Mesh.m
@@ -17,8 +17,29 @@ classdef Mesh < CortidQCT.lib.ObjectBase
       
       if nargin == 0
         handle = ObjectBase.call('createMesh');
-      else
+      elseif nargin == 1
         handle = varargin{1};
+      elseif nargin == 2 || nargin == 3
+        V = varargin{1};
+        F = varargin{2};
+        if nargin == 3
+          L = varargin{3};
+        else
+          L = zeros(size(V, 1), 'uint32');
+        end
+
+        err = Error;
+        handle = ObjectBase.call('createMeshAndAllocateMemory', size(V, 1), size(F, 1), err.pointer)
+        if handle == 0
+          error('Failed to create mesh: %s', err.message);
+        end
+
+        obj@CortidQCT.lib.ObjectBase(handle);
+
+        obj.Vertices = V;
+        obj.Indices = F;
+        obj.Labels = L;
+        return
       end
       
       obj@CortidQCT.lib.ObjectBase(handle);

--- a/bindings/matlab/+CortidQCT/+lib/Mesh.m
+++ b/bindings/matlab/+CortidQCT/+lib/Mesh.m
@@ -14,6 +14,7 @@ classdef Mesh < CortidQCT.lib.ObjectBase
     % Constructor
     function obj = Mesh(varargin)
       import CortidQCT.lib.ObjectBase;
+      import CortidQCT.lib.Error;
       
       if nargin == 0
         handle = ObjectBase.call('createMesh');
@@ -25,7 +26,7 @@ classdef Mesh < CortidQCT.lib.ObjectBase
         if nargin == 3
           L = varargin{3};
         else
-          L = zeros(size(V, 1), 'uint32');
+          L = zeros(size(V, 1), 1, 'uint32');
         end
 
         err = Error;
@@ -33,16 +34,15 @@ classdef Mesh < CortidQCT.lib.ObjectBase
         if handle == 0
           error('Failed to create mesh: %s', err.message);
         end
-
-        obj@CortidQCT.lib.ObjectBase(handle);
-
-        obj.Vertices = V;
-        obj.Indices = F;
-        obj.Labels = L;
-        return
       end
       
       obj@CortidQCT.lib.ObjectBase(handle);
+
+      if nargin == 2 || nargin == 3
+        obj.Vertices = V;
+        obj.Indices = F;
+        obj.Labels = L;
+      end
     end
 
     %%%%%%%%%%%%%%%%%
@@ -74,8 +74,8 @@ classdef Mesh < CortidQCT.lib.ObjectBase
         error('V must be a Nx3 single matrix')
       end
 
-      if size(V, 1) ~= obj.VertexCount
-        error('Number of rows of V must match VertexCount')
+      if size(V, 1) ~= obj.vertexCount
+        error('Number of rows of V must match vertexCount')
       end
 
       ObjectBase.call('meshSetVertices', obj.handle, V');
@@ -93,16 +93,19 @@ classdef Mesh < CortidQCT.lib.ObjectBase
       import CortidQCT.lib.ObjectBase;
 
       if size(F, 2) ~= 3
-        error('V must be a Mx3 single matrix')
+        error('F must be a Mx3 single matrix')
       end
 
       if ~isa(F, 'int64')
         F = int64(F);
       end
 
-      if size(F, 1) ~= obj.VertexCount
-        error('Number of rows of F must match TriangleCount')
+      if size(F, 1) ~= obj.triangleCount
+        error('Number of rows of F must match triangleCount')
       end
+
+      % Convert from matlab's 1 bases indexing to C's 0 based indexing
+      F = F - 1;
 
       ObjectBase.call('meshSetTriangles', obj.handle, F');
     end
@@ -126,12 +129,12 @@ classdef Mesh < CortidQCT.lib.ObjectBase
         L = L';
       end
 
-      if ~isa(F, 'uint32')
-        F = uint32(F);
+      if ~isa(L, 'uint32')
+        F = uint32(L);
       end
 
-      if size(F, 1) ~= obj.VertexCount
-        error('Number of rows of L must match TriangleCount')
+      if numel(L) ~= obj.vertexCount
+        error('Number of rows of L must match vertexCount')
       end
 
       ObjectBase.call('meshSetLabels', obj.handle, L);

--- a/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
+++ b/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
@@ -259,6 +259,17 @@ CQCT_EXTERN size_t CQCT_meshTriangleCount(CQCT_Mesh mesh);
 CQCT_EXTERN size_t CQCT_meshCopyVertices(CQCT_Mesh mesh, float **bufferPtr);
 
 /**
+ * @brief Copies the vertices from the given buffer into the mesh data
+ * structure.
+ *
+ * @note Vertices are expected to have the oder [v1x, v1y, v1z, v2x, v2y, v2z,
+ * ...]
+ * @param[in,out] mesh mesh to set the vertices for
+ * @param[in] buffer buffer to copy the vertices from
+ */
+CQCT_EXTERN void CQCT_meshSetVertices(CQCT_Mesh mesh, float const *buffer);
+
+/**
  * @brief Copies the mesh's indices into the given buffer
  * @see CQCT_meshCopyVertices()
  */
@@ -266,11 +277,32 @@ CQCT_EXTERN size_t CQCT_meshCopyTriangles(CQCT_Mesh mesh,
                                           ptrdiff_t **bufferPtr);
 
 /**
+ * @brief Copies the triangle indices from the given buffer into the mesh data
+ * structure.
+ *
+ * @note Vertices are expected to have the oder [i11, i12, i13, i21, i22, i23,
+ * ...], where im, denotes the m-th index of the n-th triangle.
+ * @param[in,out] mesh mesh to set the indices for
+ * @param[in] buffer buffer to copy the indices from
+ */
+CQCT_EXTERN void CQCT_meshSetTriangles(CQCT_Mesh mesh, ptrdiff_t const *buffer);
+
+/**
  * @brief Copies the mesh's labels into the given buffer
  * @see CQCT_meshCopyVertices()
  */
 CQCT_EXTERN size_t CQCT_meshCopyLabels(CQCT_Mesh mesh,
                                        unsigned int **bufferPtr);
+
+/**
+ * @brief Copies the vertex labels from the given buffer into the mesh data
+ * structure.
+ *
+ * @param[in,out] mesh mesh to set the indices for
+ * @param[in] buffer buffer to copy the indices from
+ */
+CQCT_EXTERN void CQCT_meshSetLabels(CQCT_Mesh mesh, unsigned int const *buffer);
+
 
 /// @}
 

--- a/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
+++ b/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
@@ -149,6 +149,27 @@ typedef struct CQCT_Mesh_t *CQCT_Mesh;
 CQCT_EXTERN CQCT_Mesh CQCT_createMesh(void);
 
 /**
+ * @brief Creates an mesh and reserve space for vertices and indices.
+ *
+ * Creates a mesh data structure and allocate memory for vertices, indices and
+ * labels.
+ *
+ * @param[in] nVertices Number of vertices to allocate memory for
+ * @param[in] nTriangles Number of triangles to allocate memory for
+ * @param[out] error In case of an error, an error object is copied to
+ * `*error`. NULL may be passed here to not get any error objects.
+ * @return A newly created CQCT_Mesh opbject or NULL on error.
+ * @note The ownership of the mesh object is transfered to the caller.
+ * @note The ownership of the error object is NOT transfered to teh caller.
+ * @note It is very unlikely that this function returns an error. The only
+ * reason for failure is when the system is unable to allocate enough memory.
+ * It is therefore kind of save to pass NULL for `error` here.
+ */
+CQCT_EXTERN CQCT_Mesh CQCT_createMeshAndAllocateMemory(size_t nVertices,
+                                                       size_t nTriangles,
+                                                       CQCT_Error *error);
+
+/**
  * @brief Creates and loads a mesh from file.
  *
  * @param[in] filename path to the file to load the mesh from

--- a/matlab/CortidQCT.prj
+++ b/matlab/CortidQCT.prj
@@ -9,7 +9,7 @@
 
 For details visit https://github.com/ithron/CortidQCT</param.description>
     <param.screenshot />
-    <param.version>1.2.2.3</param.version>
+    <param.version>1.2.2.4</param.version>
     <param.output>${PROJECT_ROOT}/CortidQCT.mltbx</param.output>
     <param.products.name>
       <item>MATLAB</item>


### PR DESCRIPTION
Add C and MATLAB API function to create and modify meshes.

For the C-API these functions are:
- `CQCT_createMeshAndAllocateMemory(size_t nVertices, size_t nTriangles)`: Creates a mesh object and allocates enough memory to hold `nVertices` vertices and labels and `nTriangles` triangle indices.
- `CQCT_meshSetVertices(CQCT_Mesh mesh, float const *buffer)`: Copies vertices from `buffer` into the mesh vertex storage
- `CQCT_meshSetTriangles(CQCT_Mesh mesh, ptrdiff_t const *buffer)`: Copies triangles indices from `buffer` into the mesh index storage
- `CQCT_meshSetLabel(CQCT_Mesh mesh. unsigned int const *buffer)`: Copies the labels from `buffer` into the mesh label storage.

In the MATLAB-API the following setters were added:
- set.Vertices
- set.Indices
- set.Labels

The constructor was extended to take two (or three) matrices as parameters and then constructs a mesh with the given vertices and indices (and labels).
If no labels are given, the labels are initialized with zeroes.  