### PR TITLE
Add option to ignore samples outside the volume

### DIFF
--- a/include/CortidQCT/src/MeshFitter.h
+++ b/include/CortidQCT/src/MeshFitter.h
@@ -57,6 +57,8 @@ public:
     std::size_t minNonDecreasing = 10;
     /// Decay factor
     float decay = 0.9f;
+    /// Ignore samples outisde the volumes?
+    bool ignoreExteriorSamples = false;
 
     /**
      * @brief Reference mesh origin

--- a/lib/MeshFitterConfiguration.cpp
+++ b/lib/MeshFitterConfiguration.cpp
@@ -215,6 +215,10 @@ MeshFitter::Configuration::loadFromFile(std::string const &filename) {
 
     if (auto decayNode = node["decay"]) { decay = decayNode.as<float>(); }
 
+    if (auto ignoreExteriorSamplesNode = node["ignoreExteriorSamples"]) {
+      ignoreExteriorSamples = ignoreExteriorSamplesNode.as<bool>();
+    }
+
     model = std::move(model_);
     referenceMesh = std::move(refMesh);
 

--- a/lib/MeshFitterImpl.cpp
+++ b/lib/MeshFitterImpl.cpp
@@ -255,7 +255,9 @@ void MeshFitter::Impl::sampleVolume(MeshFitter::State &state) const {
       samplingPoints(V.transpose(), N.transpose(), conf.model).transpose();
 
   // Sample the volume
-  auto const volumeSampler = VolumeSampler{state.hiddenState_->volume};
+  auto const volumeSampler = VolumeSampler{
+      state.hiddenState_->volume,
+      conf.ignoreExteriorSamples ? std::numeric_limits<float>::quiet_NaN() : 0.f};
   volumeSampler(volumeSamplingPositions.transpose(), volumeSamples);
 
   // Reorder samples


### PR DESCRIPTION
The options is called 'ignoreExteriorSamples' and is a boolean that
defaults to false.
This is an implementation of issue #52.