### PR TITLE
Simplify version management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,10 @@ include(GNUInstallDirs)
 # Create project
 project(
   CortidQCT
-  VERSION 1.2.2
+  VERSION 1.2.2.16
   LANGUAGES C CXX
 )
+
 
 find_package(OpenMP)
 if (OpenMP_FOUND)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 # Create project
 project(
   CortidQCTApplication
-  VERSION 1.2.2
+  VERSION ${CortidQCT_VERSION}
   LANGUAGES CXX
 )
 

--- a/bindings/C/CMakeLists.txt
+++ b/bindings/C/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(
   CortidQCT-C-Bindings
-  VERSION 1.2.2
+  VERSION ${CortidQCT_VERSION}
   LANGUAGES CXX
 )
 

--- a/bindings/C/examples/CMakeLists.txt
+++ b/bindings/C/examples/CMakeLists.txt
@@ -6,7 +6,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Init.cmake)
 # Create project
 project(
   CortidQCT-C-Bindings-Examples
-  VERSION 1.0.0
+  VERSION ${CortidQCT_VERSION}
   LANGUAGES C
 )
 

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(
   CortidQCT-MATLAB-Bindings
-  VERSION 1.2.2
+  VERSION ${CortidQCT_VERSION}
   LANGUAGES C
 )
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 target_include_directories(Common
   INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -91,6 +92,20 @@ if (CortidQCT_WITH_OPENMP)
 endif()
 
 add_library(CortidQCT::Common ALIAS Common)
+
+###############################
+# Version Configuration File
+
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../include/CortidQCT/src/Version.h.in src/Version.h)
+
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/src/Version.h"
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/CortidQCT/src/
+)
+
 
 ############################
 # Exports

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -7,7 +7,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Init.cmake)
 
 project(
   CortidQCT-Common
-  VERSION 1.2.2
+  VERSION ${CortidQCT_VERSION}
   LANGUAGES CXX
 )
 

--- a/include/CortidQCT/CortidQCT.h
+++ b/include/CortidQCT/CortidQCT.h
@@ -15,6 +15,7 @@
 #include "src/Mesh.h"
 #include "src/MeshFitter.h"
 #include "src/VoxelVolume.h"
+#include "src/Version.h"
 
 /**
  * @brief Name namespace for CortidQCT library

--- a/include/CortidQCT/src/Version.h.in
+++ b/include/CortidQCT/src/Version.h.in
@@ -1,0 +1,19 @@
+/**
+ * @file      Version.h
+ *
+ * @brief     This file contains version information for the CortidQCT project.
+ *
+ * @author    Stefan Reinhold
+ * @copyright Copyright (C) 2019 Stefan Reinhold  -- All Rights Reserved.
+ *            You may use, distribute and modify this code under the terms of
+ *            the AFL 3.0 license; see LICENSE for full license details.
+ */
+
+#pragma once
+
+#cmakedefine CortidQCT_VERSION "@CortidQCT_VERSION@"
+#cmakedefine CortidQCT_VERSION_MAJOR @CortidQCT_VERSION_MAJOR@
+#cmakedefine CortidQCT_VERSION_MINOR @CortidQCT_VERSION_MINOR@
+#cmakedefine CortidQCT_VERSION_PATCH @CortidQCT_VERSION_PATCH@
+#cmakedefine CortidQCT_VERSION_TWEAK @CortidQCT_VERSION_TWEAK@
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,7 +7,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Init.cmake)
 
 project(
   LibCortidQCT
-  VERSION 1.2.2
+  VERSION ${CortidQCT_VERSION}
   LANGUAGES CXX
 )
 

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(
   CortidQCT-MATLAB
-  VERSION 1.2.2
+  VERSION ${CortidQCT_VERSION}
   LANGUAGES C
 )
 

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -30,6 +30,12 @@ if (BUILD_MEX)
   add_library(CortidQCT::matlab ALIAS matlab)
 endif()
 
+##########################
+# Package configuration
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CortidQCT.prj.in CortidQCT.prj)
+
+
 ############################
 # Exports
 
@@ -48,10 +54,10 @@ install(
   DESTINATION
     "${CortidQCT_Toolbox_ROOT}/toolbox"
 )
+
 install(
   FILES
-    "${CMAKE_CURRENT_SOURCE_DIR}/CortidQCT.prj"
+    "${CMAKE_CURRENT_BINARY_DIR}/CortidQCT.prj"
   DESTINATION
-    "${CortidQCT_Toolbox_ROOT}"
+    ${CortidQCT_Toolbox_ROOT}
 )
-

--- a/matlab/CortidQCT.prj.in
+++ b/matlab/CortidQCT.prj.in
@@ -9,7 +9,7 @@
 
 For details visit https://github.com/ithron/CortidQCT</param.description>
     <param.screenshot />
-    <param.version>1.2.2.16</param.version>
+    <param.version>@CortidQCT_VERSION@</param.version>
     <param.output>${PROJECT_ROOT}/CortidQCT.mltbx</param.output>
     <param.products.name>
       <item>MATLAB</item>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Init.cmake)
 # Project
 project(
   CortidQCT-Tests
-  VERSION 1.2.2
+  VERSION ${CortidQCT_VERSION}
   LANGUAGES CXX
 )
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2)
 
 project(
   CortidQCT-Tools
-  VERSION 1.2.2
+  VERSION ${CortidQCT_VERSION}
 )
 
 ############################


### PR DESCRIPTION
This PR fixes issue #55.
The project version is kept at the top level CMakeLists.txt file and cmake will promote the version to all sub projects. Also the MATLAB toolbox project file gets updated automatically.