### PR TITLE
Mesh upsampling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 # Create project
 project(
   CortidQCT
-  VERSION 1.2.2.19
+  VERSION 1.2.2.20
   LANGUAGES C CXX
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 # Create project
 project(
   CortidQCT
-  VERSION 1.2.2.18
+  VERSION 1.2.2.19
   LANGUAGES C CXX
 )
 

--- a/bindings/C/include/CortidQCT/C/CortidQCT.h
+++ b/bindings/C/include/CortidQCT/C/CortidQCT.h
@@ -437,6 +437,15 @@ CQCT_EXTERN void
 CQCT_meshRayIntersections(CQCT_Mesh mesh, CQCT_Ray *raysPtr, size_t nRays,
                           CQCT_RayMeshIntersection **intersectionsOutPtr);
 
+/**
+ * @brief Upsamples the given mesh `nTimes` without touchting the original
+ * vertices
+ *
+ * @param nTimes number of upsample iterations
+ * @pre `mesh != null || nTimes == 0`
+ */
+CQCT_EXTERN void CQCT_meshUpsample(CQCT_Mesh mesh, size_t nTimes);
+
 /// @}
 
 // MARK: -

--- a/bindings/C/src/Mesh.cpp
+++ b/bindings/C/src/Mesh.cpp
@@ -349,3 +349,12 @@ CQCT_meshRayIntersections(CQCT_Mesh mesh, CQCT_Ray *raysPtr, size_t nRays,
   mesh->impl.objPtr->rayIntersections(raysBegin, raysEnd, intersectionsOut);
 }
 
+CORTIDQCT_C_EXPORT CQCT_EXTERN void CQCT_meshUpsample(CQCT_Mesh mesh,
+                                                      size_t nTimes) {
+  if (nTimes == 0) return;
+
+  assert(mesh != nullptr);
+
+  mesh->impl.objPtr->upsample(nTimes);
+}
+

--- a/bindings/matlab/+CortidQCT/+lib/Mesh.m
+++ b/bindings/matlab/+CortidQCT/+lib/Mesh.m
@@ -211,6 +211,18 @@ classdef Mesh < CortidQCT.lib.ObjectBase
       VT = [obj.Vertices, ones(obj.vertexCount, 1)] * T';
       obj.Vertices = VT(:, 1:3);
     end
+
+    function obj = upsample(obj, nTimes)
+      % UPSAMPLE Upsamples the mesh using loop subdivision but without touching
+      % the orginal vertices.
+      %   obj = upsample(obj, nTimes)
+      % Upsamples the mesh `nTimes`.
+
+      import CortidQCT.lib.ObjectBase;
+
+      ObjectBase.call('meshUpsample', obj.handle, nTimes);
+
+    end
     
     %%%%%%%%%%%%%%%%%
     %% Queries

--- a/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
+++ b/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
@@ -405,6 +405,15 @@ CQCT_EXTERN void
 CQCT_meshRayIntersections(CQCT_Mesh mesh, CQCT_Ray *raysPtr, size_t nRays,
                           CQCT_RayMeshIntersection **intersectionsOutPtr);
 
+/**
+ * @brief Upsamples the given mesh `nTimes` without touchting the original
+ * vertices
+ *
+ * @param nTimes number of upsample iterations
+ * @pre `mesh != null || nTimes == 0`
+ */
+CQCT_EXTERN void CQCT_meshUpsample(CQCT_Mesh mesh, size_t nTimes);
+
 /// @}
 
 // MARK: -

--- a/include/CortidQCT/src/Mesh.h
+++ b/include/CortidQCT/src/Mesh.h
@@ -301,6 +301,21 @@ public:
   /// @}
 
   /**
+   * @name Modifyers
+   * @{
+   */
+
+  /**
+   * @brief Upsample the mesh without touching the original vertices
+   *
+   * @param nTimes number of subsample iterations
+   * @return Reference to `*this`
+   */
+  Mesh<T> &upsample(std::size_t nTimes = 1);
+
+  /// @}
+
+  /**
    * @name Raw Data Access
    * The methods in this section all call a functional with a pointer to raw
    * data as its argument. The pointer only guaranteed to be valid within the


### PR DESCRIPTION
Adds Mesh::upsample() method to Mesh class.
The upsamling uses loop subdivision but without changing the vertex positions of the original vertices