### PR TITLE
Deprecate MeshFitter::State::vertexNormals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 # Create project
 project(
   CortidQCT
-  VERSION 1.2.2.28
+  VERSION 1.2.2.29
   LANGUAGES C CXX
 )
 

--- a/bindings/C/include/CortidQCT/C/CortidQCT.h
+++ b/bindings/C/include/CortidQCT/C/CortidQCT.h
@@ -568,8 +568,11 @@ CQCT_EXTERN void CQCT_meshFitterResultSetWeights(CQCT_MeshFitterResult result,
                                                  float const *buffer);
 
 /// Copies the vertex normals
+/// @deprecated Deprecated since version 1.3, will be removed in 2.0. Use the
+/// per-vertex normals property of the defomed mesh instead.
 CQCT_EXTERN size_t CQCT_meshFitterResultCopyVertexNormals(
-    CQCT_MeshFitterResult result, float **buffer);
+    CQCT_MeshFitterResult result, float **buffer)
+    __attribute__((deprecated("Use normals stored in deformedMesh instead.")));
 
 /// Returns the number of volume sampling positions
 CQCT_EXTERN size_t

--- a/bindings/C/src/MeshFitterState.cpp
+++ b/bindings/C/src/MeshFitterState.cpp
@@ -150,12 +150,12 @@ CORTIDQCT_C_EXPORT CQCT_EXTERN size_t CQCT_meshFitterResultCopyVertexNormals(
 
   auto const &state = result->impl.objPtr->state;
 
-  auto const size = state.vertexNormals.size() * 3 * sizeof(float);
+  auto const size = state.deformedMesh.vertexCount() * 3 * sizeof(float);
 
   if (*buffer == nullptr) { *buffer = static_cast<float *>(malloc(size)); }
 
-  memcpy(*buffer, reinterpret_cast<float const *>(state.vertexNormals.data()),
-         size);
+  state.deformedMesh.withUnsafeVertexNormalPointer(
+      [size, buffer](float const *ptr) { memcpy(*buffer, ptr, size); });
 
   return size;
 }

--- a/bindings/matlab/+CortidQCT/+lib/MeshFitterResult.m
+++ b/bindings/matlab/+CortidQCT/+lib/MeshFitterResult.m
@@ -96,12 +96,15 @@ classdef MeshFitterResult < CortidQCT.lib.ObjectBase
     end
 
     function vertexNormals = get.vertexNormals(obj)
+      % VERTEXNORMALS Returns the vertex normals of the deformed mesh
+      %   vertexNormals = get.vertexNormals(obj)
+      % DEPRECATED: Will be removed in version 2.0. Use `mesh.Normals`
+      % instead.
       import CortidQCT.lib.ObjectBase;
 
-      buffer = libpointer('singlePtr', zeros(3, obj.mesh.vertexCount, 'single'));
-      result = ObjectBase.call('meshFitterResultCopyVertexNormals', obj.handle, buffer);
-      assert(result == 3 * 4 * obj.mesh.vertexCount, "Size mismatch");
-      vertexNormals = buffer.Value';
+      warning('MeshFitterResult.vertexNormals is deprecated and will be removed in version 2.0. Use mesh.Normals instead.');
+
+      vertexNormals = mesh.Normals;
     end
 
     function volumeSamplingPositions = get.volumeSamplingPositions(obj)

--- a/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
+++ b/bindings/matlab/include/CortidQCT/Matlab/CortidQCT.h
@@ -526,8 +526,11 @@ CQCT_meshFitterResultCopyWeights(CQCT_MeshFitterResult result, float **buffer);
 CQCT_EXTERN void CQCT_meshFitterResultSetWeights(CQCT_MeshFitterResult result,
                                                  float const *buffer);
 /// Copies the vertex normals
+/// @deprecated Deprecated since version 1.3, will be removed in 2.0. Use the
+/// per-vertex normals property of the defomed mesh instead.
 CQCT_EXTERN size_t CQCT_meshFitterResultCopyVertexNormals(
-    CQCT_MeshFitterResult result, float **buffer);
+    CQCT_MeshFitterResult result, float **buffer)
+    __attribute__((deprecated("Use normals stored in deformedMesh instead.")));
 
 /// Returns the number of volume sampling positions
 CQCT_EXTERN size_t

--- a/include/CortidQCT/src/MeshFitter.h
+++ b/include/CortidQCT/src/MeshFitter.h
@@ -136,8 +136,13 @@ public:
     float minDisNorm = std::numeric_limits<float>::max();
     /// Log likeihood of deformedMesh
     float logLikelihood = -std::numeric_limits<float>::max();
-    /// Per-vertex log likelihood vector
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
+    /// @brief Per-vertex log likelihood vector (**deprecated**)
+    /// @deprecated Deprecated since version 1.3. The the vertex normals stored
+    // in `deformedMesh` instead. Will be removed in version 2.0.
     std::vector<float> perVertexLogLikelihood;
+#pragma clang diagnostic pop
     /// Effective sigmaS
     float effectiveSigmaS = .0f;
     /// Iteration count


### PR DESCRIPTION
Also deprecate the corresponding C and MATLAB API calls.
Also changed all internal code to use the vertex normals of the mesh object instead.
