### PR TITLE
Fix: std::vector initialized with too many elements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 # Create project
 project(
   CortidQCT
-  VERSION 1.2.2.34
+  VERSION 1.2.2.35
   LANGUAGES C CXX
 )
 

--- a/lib/MeshFitterImpl.cpp
+++ b/lib/MeshFitterImpl.cpp
@@ -145,7 +145,7 @@ MeshFitter::State MeshFitter::Impl::init(VoxelVolume const &volume) const {
   // Init vertex normals
   state.referenceMesh.updatePerVertexNormals();
   // This will be removed in versino 2.0:
-  state.vertexNormals.resize(3 * narrow_cast<std::size_t>(nVertices));
+  state.vertexNormals.resize(narrow_cast<std::size_t>(nVertices));
   Adaptor::map(state.vertexNormals) = Adaptor::vertexNormalMap(state.referenceMesh);
 
   // Init deformed mesh with reference mesh


### PR DESCRIPTION
state.vertexNormals was initialized with 3 * nVertices, but vertexNormals is actually a std::vector of std::array<3, float> so that its size was three times too large. This resulted in an assertion failure when copying over the vertex normals from the mesh.
This fixes issue #71.