### PR TITLE
Fix #70: Crash when using MeshFitter.fit(volume) from MATLAB 2019b

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 # Create project
 project(
   CortidQCT
-  VERSION 1.2.2.35
+  VERSION 1.2.2.36
   LANGUAGES C CXX
 )
 

--- a/lib/MeshFitterHiddenState.cpp
+++ b/lib/MeshFitterHiddenState.cpp
@@ -23,7 +23,9 @@ using namespace Internal;
 
 MeshFitter::State::State(State const &rhs)
     : Result(rhs), hiddenState_{
-                       std::make_unique<HiddenState>(*rhs.hiddenState_)} {}
+                       rhs.hiddenState_ != nullptr
+                           ? std::make_unique<HiddenState>(*rhs.hiddenState_)
+                           : nullptr} {}
 
 MeshFitter::State::State(Result const &rhs)
     : Result(rhs), hiddenState_{nullptr} {}
@@ -31,7 +33,7 @@ MeshFitter::State::State(Result const &rhs)
 MeshFitter::State::State(Result &&rhs)
     : Result(std::move(rhs)), hiddenState_{nullptr} {}
 
-MeshFitter::State::~State(){}
+MeshFitter::State::~State() {}
 
 MeshFitter::State &MeshFitter::State::operator=(State const &rhs) {
   static_cast<Result &>(*this) = rhs;


### PR DESCRIPTION
The crash was caused by a null pointer dereferencing in the constructor of MeshFitter::State which could only be caused by the C API.